### PR TITLE
Multiple Elements Matched - Error Formatting

### DIFF
--- a/AppFramework/Core/GREYElementInteraction.m
+++ b/AppFramework/Core/GREYElementInteraction.m
@@ -589,7 +589,6 @@
         break;
       }
       case kGREYInteractionMultipleElementsMatchedErrorCode: {
-        errorDetails[kErrorDetailActionNameKey] = action.name;
         errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
         
         NSString *recoverySuggestion1 = @"Create a more specific matcher to uniquely match the "
@@ -614,7 +613,7 @@
         }
 
         NSArray *keyOrder = @[
-          kErrorDetailActionNameKey, kErrorDetailElementMatcherKey,
+          kErrorDetailElementMatcherKey,
           kErrorDetailRecoverySuggestionKey
         ];
         NSString *reasonDetail = [GREYObjectFormatter formatDictionary:errorDetails

--- a/AppFramework/Core/GREYElementInteraction.m
+++ b/AppFramework/Core/GREYElementInteraction.m
@@ -591,14 +591,24 @@
       case kGREYInteractionMultipleElementsMatchedErrorCode: {
         errorDetails[kErrorDetailActionNameKey] = action.name;
         errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
-        errorDetails[kErrorDetailRecoverySuggestionKey] =
-            @"Create a more specific matcher to uniquely match an element.\n\nIn general, prefer "
-            @"using accessibility ID before accessibility label or other attributes. If you are "
-            @"matching on a UIButton, please use grey_buttonTitle() with the accessibility label "
-            @"instead. For UITextField, please use grey_textFieldValue().\n\nIf that's not "
-            @"possible then use atIndex: to select from one of the matched elements. Keep "
-            @"in mind when using atIndex: that the order in which elements are "
-            @"arranged may change, making your test brittle.";
+        
+        NSString *recoverySuggestion1 = @"Create a more specific matcher to uniquely match the "
+                                        @"element.\nIn general, prefer using accessibility ID "
+                                        @"before accessibility label or other attributes.";
+        NSString *recoverySuggestion2;
+        if ([_elementMatcher.description containsString:@"UIButton"]) {
+          recoverySuggestion2 = @"Use grey_buttonTitle() with the accessibility label for "
+                                @"a UIButton.";
+        } else if ([_elementMatcher.description containsString:@"UITextField"]) {
+          recoverySuggestion2 = @"Use grey_textFieldValue() for a UITextField.";
+        } else {
+          recoverySuggestion2 = @"Use atIndex: to select from one of the matched elements.\n"
+                                @"Keep in mind when using atIndex: that the order in which "
+                                @"elements are arranged may change, making your test brittle.";
+        }
+        errorDetails[kErrorDetailRecoverySuggestionKey]
+            = [NSString stringWithFormat:@"%@\n%@", recoverySuggestion1, recoverySuggestion2];
+        
         if (searchAPIInfo) {
           errorDetails[kErrorDetailSearchActionInfoKey] = searchAPIInfo;
         }
@@ -842,6 +852,9 @@
                                          code:interactionError.code
                                      userInfo:userInfo];
   }
+  if ([interactionError isKindOfClass:[GREYError class]]) {
+    wrappedError.multipleElementsMatched = interactionError.multipleElementsMatched;
+  }
   return wrappedError;
 }
 
@@ -874,24 +887,26 @@
     // Populate with an error specifying that the index provided for matching the multiple elements
     // was out of bounds.
     errorDescription =
-        [NSString stringWithFormat:@"Multiple elements were matched: %@ with an "
+        [NSString stringWithFormat:@"Multiple elements were matched with an "
                                    @"index that is out of bounds of the number of "
                                    @"matched elements. Please use an element "
                                    @"index from 0 to %tu",
-                                   elementDescriptions, (elementDescriptions.count - 1)];
+                                   (elementDescriptions.count - 1)];
     errorCode = kGREYInteractionMatchedElementIndexOutOfBoundsErrorCode;
   } else {
     // Populate with an error specifying that multiple elements were matched without providing
     // an index.
-    errorDescription = [NSString stringWithFormat:@"Multiple elements were matched: %@. Please "
+    errorDescription = [NSString stringWithFormat:@"Multiple elements were matched. Please "
                                                   @"use selection matchers to narrow the "
-                                                  @"selection down to a single element.",
-                                                  elementDescriptions];
+                                                  @"selection down to a single element."];
     errorCode = kGREYInteractionMultipleElementsMatchedErrorCode;
   }
 
   // Populate the user info for the multiple matching elements error.
-  return GREYErrorMakeWithHierarchy(kGREYInteractionErrorDomain, errorCode, errorDescription);
+  GREYError *error = GREYErrorMakeWithHierarchy(kGREYInteractionErrorDomain, errorCode,
+                                                errorDescription);
+  error.multipleElementsMatched = elementDescriptions;
+  return error;
 }
 
 /**

--- a/CommonLib/Error/GREYError+Private.h
+++ b/CommonLib/Error/GREYError+Private.h
@@ -87,6 +87,7 @@ GREY_EXTERN NSString *const kErrorAppScreenShotsKey;
 @property(nonatomic) NSUInteger line;
 @property(nonatomic) NSString *functionName;
 @property(nonatomic) NSDictionary *errorInfo;
+@property(nonatomic) NSArray<NSString *> *multipleElementsMatched;
 @property(nonatomic) NSArray *stackTrace;
 @property(nonatomic) NSString *appUIHierarchy;
 @property(nonatomic) NSDictionary *appScreenshots;

--- a/CommonLib/Error/GREYError.h
+++ b/CommonLib/Error/GREYError.h
@@ -94,6 +94,11 @@ GREY_EXTERN NSString *const kErrorDetailAssertCriteriaKey;
 GREY_EXTERN NSString *const kErrorDetailRecoverySuggestionKey;
 
 /**
+ * Key used to retrieve the list of elements matched when multiple elements are matched.
+ */
+GREY_EXTERN NSString *const kErrorDetailElementsMatchedKey;
+
+/**
  * Key used to retrieve the error domain from an error object.
  */
 GREY_EXTERN NSString *const kErrorDomainKey;

--- a/CommonLib/Error/GREYError.m
+++ b/CommonLib/Error/GREYError.m
@@ -27,6 +27,7 @@ NSString *const kErrorDetailActionNameKey = @"Action Name";
 NSString *const kErrorDetailSearchActionInfoKey = @"Search API Info";
 NSString *const kErrorDetailAssertCriteriaKey = @"Assertion Criteria";
 NSString *const kErrorDetailRecoverySuggestionKey = @"Recovery Suggestion";
+NSString *const kErrorDetailElementsMatchedKey = @"Elements Matched";
 
 NSString *const kErrorDomainKey = @"Error Domain";
 NSString *const kErrorCodeKey = @"Error Code";
@@ -63,6 +64,7 @@ NSString *const kGREYScreenshotActualAfterImage =
 @property(nonatomic, readwrite) NSUInteger line;
 @property(nonatomic, readwrite) NSString *functionName;
 @property(nonatomic, readwrite) NSDictionary *errorInfo;
+@property(nonatomic, readwrite) NSArray<NSString *> *multipleElementsMatched;
 @property(nonatomic, readwrite) NSArray *stackTrace;
 @property(nonatomic, readwrite) NSString *appUIHierarchy;
 @property(nonatomic, readwrite) NSDictionary *appScreenshots;
@@ -91,6 +93,7 @@ GREYError *I_GREYErrorMake(NSString *domain, NSInteger code, NSDictionary *userI
   NSUInteger _line;
   NSString *_functionName;
   NSDictionary *_errorInfo;
+  NSArray<NSString *> *_multipleElementsMatched;
   NSArray *_stackTrace;
   NSString *_appUIHierarchy;
   NSDictionary *_appScreenshots;

--- a/Tests/Functional/Sources/ErrorHandlingTest.m
+++ b/Tests/Functional/Sources/ErrorHandlingTest.m
@@ -67,28 +67,6 @@
 }
 
 /**
- * Check error for multiple matchers.
- */
-- (void)testMultipleMatcherError {
-  NSError *error;
-  [[EarlGrey selectElementWithMatcher:grey_kindOfClass([UITableViewCell class])]
-      performAction:grey_tap()
-              error:&error];
-  XCTAssertNotNil(error, @"Multiple Matchers error for the main VC is nil.");
-  NSString *suggestion =
-      @"Create a more specific matcher to uniquely match an element.\n\nIn general, prefer "
-      @"using accessibility ID before accessibility label or other attributes. If you are "
-      @"matching on a UIButton, please use grey_buttonTitle() with the accessibility label "
-      @"instead. For UITextField, please use grey_textFieldValue().\n\nIf that's not "
-      @"possible then use atIndex: to select from one of the matched elements. Keep "
-      @"in mind when using atIndex: that the order in which elements are "
-      @"arranged may change, making your test brittle.";
-  XCTAssertTrue([error.description containsString:suggestion],
-                @"Multiple Matcher Error: %@ doesn't contain the fixing-suggestion: %@",
-                error.description, suggestion);
-}
-
-/**
  * Check that the correct error description is printed when an error is returned from a custom
  * action.
  */
@@ -149,7 +127,7 @@
       onElementWithMatcher:grey_kindOfClass([UIView class])]
       assertWithMatcher:grey_sufficientlyVisible()
                   error:&error];
-  searchActionDescription = @"Search action failed: Multiple elements were matched:";
+  searchActionDescription = @"Search action failed: Multiple elements were matched";
   XCTAssertTrue([error.description containsString:searchAPIDescription],
                 @"Search API Prefix and Action info: %@ not present in Error Description: %@",
                 searchAPIDescription, error.description);
@@ -197,7 +175,7 @@
   [[[EarlGrey selectElementWithMatcher:matcher]
          usingSearchAction:grey_scrollInDirection(kGREYDirectionDown, 50)
       onElementWithMatcher:grey_kindOfClass([UIView class])] performAction:grey_tap() error:&error];
-  searchActionDescription = @"Search action failed: Multiple elements were matched:";
+  searchActionDescription = @"Search action failed: Multiple elements were matched";
   XCTAssertTrue([error.description containsString:searchAPIDescription],
                 @"Search API Prefix and Action info: %@ not present in Error Description: %@",
                 searchAPIDescription, error.description);

--- a/Tests/Functional/Sources/FailureFormattingTest.m
+++ b/Tests/Functional/Sources/FailureFormattingTest.m
@@ -152,4 +152,29 @@
   XCTAssertTrue([_handler.details containsString:expectedDetails]);
 }
 
+- (void)testMultipleMatchedErrorDescription {
+  [[EarlGrey selectElementWithMatcher:grey_kindOfClass([UITableViewCell class])]
+                        performAction:grey_tap()
+                                error:nil];
+
+  NSString *expectedDetails = @"Multiple elements were matched. Please use selection matchers "
+                               @"to narrow the selection down to a single element.\n"
+                               @"\n"
+                               @"Create a more specific matcher to uniquely match the element.\n"
+                               @"In general, prefer using accessibility ID before accessibility "
+                               @"label or other attributes.\n"
+                               @"Use atIndex: to select from one of the matched elements.\n"
+                               @"Keep in mind when using atIndex: that the order in which "
+                               @"elements are arranged may change, making your test brittle.\n"
+                               @"\n"
+                               @"Element Matcher:\n"
+                               @"kindOfClass('UITableViewCell')\n"
+                               @"\n"
+                               @"Elements Matched:\n"
+                               @"\n"
+                               @"1.";
+  XCTAssertTrue([_handler.details containsString:expectedDetails]);
+  XCTAssertTrue([_handler.details containsString:@"UI Hierarchy"]);
+}
+
 @end

--- a/Tests/Functional/Sources/FailureFormattingTest.m
+++ b/Tests/Functional/Sources/FailureFormattingTest.m
@@ -158,21 +158,21 @@
                                 error:nil];
 
   NSString *expectedDetails = @"Multiple elements were matched. Please use selection matchers "
-                               @"to narrow the selection down to a single element.\n"
-                               @"\n"
-                               @"Create a more specific matcher to uniquely match the element.\n"
-                               @"In general, prefer using accessibility ID before accessibility "
-                               @"label or other attributes.\n"
-                               @"Use atIndex: to select from one of the matched elements.\n"
-                               @"Keep in mind when using atIndex: that the order in which "
-                               @"elements are arranged may change, making your test brittle.\n"
-                               @"\n"
-                               @"Element Matcher:\n"
-                               @"kindOfClass('UITableViewCell')\n"
-                               @"\n"
-                               @"Elements Matched:\n"
-                               @"\n"
-                               @"1.";
+                              @"to narrow the selection down to a single element.\n"
+                              @"\n"
+                              @"Create a more specific matcher to uniquely match the element.\n"
+                              @"In general, prefer using accessibility ID before accessibility "
+                              @"label or other attributes.\n"
+                              @"Use atIndex: to select from one of the matched elements.\n"
+                              @"Keep in mind when using atIndex: that the order in which "
+                              @"elements are arranged may change, making your test brittle.\n"
+                              @"\n"
+                              @"Element Matcher:\n"
+                              @"kindOfClass('UITableViewCell')\n"
+                              @"\n"
+                              @"Elements Matched:\n"
+                              @"\n"
+                              @"1.";
   XCTAssertTrue([_handler.details containsString:expectedDetails]);
   XCTAssertTrue([_handler.details containsString:@"UI Hierarchy"]);
 }


### PR DESCRIPTION
This change tracks the formatting of kGREYInteractionMultipleElementsMatchedErrorCode

Before & After Example

Consider this code, which results in an error:
```
[[EarlGrey selectElementWithMatcher:grey_kindOfClass([UITableViewCell class])] performAction:grey_tap() error:nil];
```

Execution Time Before: 6.954
Console Output, Before:
```
Exception: com.google.earlgrey.ElementInteractionErrorDomain

Exception Name: com.google.earlgrey.ElementInteractionErrorDomain
Exception Reason: Multiple elements were matched: (
    "<UITableViewCell:0x7f98d751a5d0; isAccessible=N; AX.frame={{0, 88}, {375, 44}}; AX.activationPoint={187.5, 110}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {375, 44}}; opaque; alpha=1; text='Accessibility Views'>",
    "<UITableViewCell:0x7f98d751f8a0; isAccessible=N; AX.frame={{0, 132}, {375, 44}}; AX.activationPoint={187.5, 154}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 44}, {375, 44}}; opaque; alpha=1; text='Action Sheets'>",
    "<UITableViewCell:0x7f98d7520ae0; isAccessible=N; AX.frame={{0, 176}, {375, 44}}; AX.activationPoint={187.5, 198}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 88}, {375, 44}}; opaque; alpha=1; text='Activity Indicator Views'>",
    "<UITableViewCell:0x7f98d7521920; isAccessible=N; AX.frame={{0, 220}, {375, 44}}; AX.activationPoint={187.5, 242}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 132}, {375, 44}}; opaque; alpha=1; text='Alert Views'>",
    "<UITableViewCell:0x7f98d77246f0; isAccessible=N; AX.frame={{0, 264}, {375, 44}}; AX.activationPoint={187.5, 286}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 176}, {375, 44}}; opaque; alpha=1; text='Animations'>",
    "<UITableViewCell:0x7f98d7725390; isAccessible=N; AX.frame={{0, 308}, {375, 44}}; AX.activationPoint={187.5, 330}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 220}, {375, 44}}; opaque; alpha=1; text='Basic Views'>",
    "<UITableViewCell:0x7f98d7726030; isAccessible=N; AX.frame={{0, 352}, {375, 44}}; AX.activationPoint={187.5, 374}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 264}, {375, 44}}; opaque; alpha=1; text='Collection Views'>",
    "<UITableViewCell:0x7f98d75234a0; isAccessible=N; AX.frame={{0, 396}, {375, 44}}; AX.activationPoint={187.5, 418}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 308}, {375, 44}}; opaque; alpha=1; text='Gesture Tests'>",
    "<UITableViewCell:0x7f98d7524140; isAccessible=N; AX.frame={{0, 440}, {375, 44}}; AX.activationPoint={187.5, 462}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 352}, {375, 44}}; opaque; alpha=1; text='Layout Tests'>",
    "<UITableViewCell:0x7f98d9f045c0; isAccessible=N; AX.frame={{0, 484}, {375, 44}}; AX.activationPoint={187.5, 506}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 396}, {375, 44}}; opaque; alpha=1; text='Multi finger swipe gestures'>",
    "<UITableViewCell:0x7f98d740a5d0; isAccessible=N; AX.frame={{0, 528}, {375, 44}}; AX.activationPoint={187.5, 550}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 440}, {375, 44}}; opaque; alpha=1; text='Network Test'>",
    "<UITableViewCell:0x7f98d740ac10; isAccessible=N; AX.frame={{0, 572}, {375, 44}}; AX.activationPoint={187.5, 594}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 484}, {375, 44}}; opaque; alpha=1; text='Picker Views'>",
    "<UITableViewCell:0x7f98d740fcf0; isAccessible=N; AX.frame={{0, 616}, {375, 44}}; AX.activationPoint={187.5, 638}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 528}, {375, 44}}; opaque; alpha=1; text='Pinch Tests'>",
    "<UITableViewCell:0x7f98d7410730; isAccessible=N; AX.frame={{0, 660}, {375, 44}}; AX.activationPoint={187.5, 682}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 572}, {375, 44}}; opaque; alpha=1; text='Presented Views'>",
    "<UITableViewCell:0x7f98d7410f30; isAccessible=N; AX.frame={{0, 704}, {375, 44}}; AX.activationPoint={187.5, 726}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 616}, {375, 44}}; opaque; alpha=1; text='Rotated Views'>",
    "<UITableViewCell:0x7f98d7727520; isAccessible=N; AX.frame={{0, 748}, {375, 44}}; AX.activationPoint={187.5, 770}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 660}, {375, 44}}; opaque; alpha=1; text='Scroll Views'>",
    "<UITableViewCell:0x7f98d74114a0; isAccessible=N; AX.frame={{0, 792}, {375, 44}}; AX.activationPoint={187.5, 814}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 704}, {375, 44}}; opaque; alpha=1; text='Simple Tap View'>"
). Please use selection matchers to narrow the selection down to single element.
Element Matcher: Multiple UI elements matched for the given criteria.
Exception with Action: {
  "Action Name" : "Tap",
  "Element Matcher" : "kindOfClass('UITableViewCell')",
  "Recovery Suggestion" : "Create a more specific matcher to uniquely match an element.

In general, prefer using accessibility ID before accessibility label or other attributes. If you are matching on a UIButton, please use grey_buttonTitle() with the accessibility label instead. For UITextField, please use grey_textFieldValue().

If that's not possible then use atIndex: to select from one of the matched elements. Keep in mind when using atIndex: that the order in which elements are arranged may change, making your test brittle."
}

Bundle ID: com.google.com.Functional.xctrunner

Stack Trace: ...

Screenshots: {
  "App-side Screenshot at Point-of-Failure" : ....
}

UI Hierarchy (ordered by window level, back to front): ...
```

Execution Time After: 6.819
Console Output, After:
```
EarlGrey Encountered an Error:

Multiple elements were matched. Please use selection matchers to narrow the selection down to a single element.

Recovery Suggestion:
Create a more specific matcher to uniquely match the element.
In general, prefer using accessibility ID before accessibility label or other attributes.
Use atIndex: to select from one of the matched elements.
Keep in mind when using atIndex: that the order in which elements are arranged may change, making your test brittle.

Element Matcher:
kindOfClass('UITableViewCell')

Elements Matched:
1. <UITableViewCell:0x7f8f51c158b0; isAccessible=N; AX.frame={{0, 88}, {375, 44}}; AX.activationPoint={187.5, 110}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {375, 44}}; opaque; alpha=1; text='Accessibility Views'>
2. <UITableViewCell:0x7f8f51c17f70; isAccessible=N; AX.frame={{0, 132}, {375, 44}}; AX.activationPoint={187.5, 154}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 44}, {375, 44}}; opaque; alpha=1; text='Action Sheets'>
3. <UITableViewCell:0x7f8f51d311b0; isAccessible=N; AX.frame={{0, 176}, {375, 44}}; AX.activationPoint={187.5, 198}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 88}, {375, 44}}; opaque; alpha=1; text='Activity Indicator Views'>
4. <UITableViewCell:0x7f8f51d31ff0; isAccessible=N; AX.frame={{0, 220}, {375, 44}}; AX.activationPoint={187.5, 242}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 132}, {375, 44}}; opaque; alpha=1; text='Alert Views'>
5. <UITableViewCell:0x7f8f51d32c90; isAccessible=N; AX.frame={{0, 264}, {375, 44}}; AX.activationPoint={187.5, 286}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 176}, {375, 44}}; opaque; alpha=1; text='Animations'>
6. <UITableViewCell:0x7f8f51d33ad0; isAccessible=N; AX.frame={{0, 308}, {375, 44}}; AX.activationPoint={187.5, 330}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 220}, {375, 44}}; opaque; alpha=1; text='Basic Views'>
7. <UITableViewCell:0x7f8f51e112a0; isAccessible=N; AX.frame={{0, 352}, {375, 44}}; AX.activationPoint={187.5, 374}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 264}, {375, 44}}; opaque; alpha=1; text='Collection Views'>
8. <UITableViewCell:0x7f8f51e188a0; isAccessible=N; AX.frame={{0, 396}, {375, 44}}; AX.activationPoint={187.5, 418}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 308}, {375, 44}}; opaque; alpha=1; text='Gesture Tests'>
9. <UITableViewCell:0x7f8f51c18310; isAccessible=N; AX.frame={{0, 440}, {375, 44}}; AX.activationPoint={187.5, 462}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 352}, {375, 44}}; opaque; alpha=1; text='Layout Tests'>
10. <UITableViewCell:0x7f8f51c116e0; isAccessible=N; AX.frame={{0, 484}, {375, 44}}; AX.activationPoint={187.5, 506}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 396}, {375, 44}}; opaque; alpha=1; text='Multi finger swipe gestures'>
11. <UITableViewCell:0x7f8f51c12520; isAccessible=N; AX.frame={{0, 528}, {375, 44}}; AX.activationPoint={187.5, 550}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 440}, {375, 44}}; opaque; alpha=1; text='Network Test'>
12. <UITableViewCell:0x7f8f51c10640; isAccessible=N; AX.frame={{0, 572}, {375, 44}}; AX.activationPoint={187.5, 594}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 484}, {375, 44}}; opaque; alpha=1; text='Picker Views'>
13. <UITableViewCell:0x7f8f51e15e80; isAccessible=N; AX.frame={{0, 616}, {375, 44}}; AX.activationPoint={187.5, 638}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 528}, {375, 44}}; opaque; alpha=1; text='Pinch Tests'>
14. <UITableViewCell:0x7f8f51c0e0a0; isAccessible=N; AX.frame={{0, 660}, {375, 44}}; AX.activationPoint={187.5, 682}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 572}, {375, 44}}; opaque; alpha=1; text='Presented Views'>
15. <UITableViewCell:0x7f8f51c0fd80; isAccessible=N; AX.frame={{0, 704}, {375, 44}}; AX.activationPoint={187.5, 726}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 616}, {375, 44}}; opaque; alpha=1; text='Rotated Views'>
16. <UITableViewCell:0x7f8f51e0ed70; isAccessible=N; AX.frame={{0, 748}, {375, 44}}; AX.activationPoint={187.5, 770}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 660}, {375, 44}}; opaque; alpha=1; text='Scroll Views'>
17. <UITableViewCell:0x7f8f51e16d00; isAccessible=N; AX.frame={{0, 792}, {375, 44}}; AX.activationPoint={187.5, 814}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 704}, {375, 44}}; opaque; alpha=1; text='Simple Tap View'>

App-side Screenshot at Point-of-Failure: ...

UI Hierarchy (ordered by window level, back to front): ...

Stack Trace: ...
```

Note that "EarlGrey Encountered an Error:" is temporary, until all error codes are using GREYErrorFormatter.