### PR TITLE
Timeout Interaction Error

### DIFF
--- a/AppFramework/Core/GREYElementInteraction.m
+++ b/AppFramework/Core/GREYElementInteraction.m
@@ -527,7 +527,7 @@
     if (([errorDomain isEqualToString:kGREYInteractionErrorDomain]) &&
         (errorCode == kGREYInteractionTimeoutErrorCode)) {
       errorDetails[kErrorDetailActionNameKey] = action.name;
-      errorDetails[kErrorDetailRecoverySuggestionKey] = @"Increase timeout for matching element";
+      errorDetails[kErrorDetailRecoverySuggestionKey] = @"Increase timeout for matching element.";
       errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
       NSArray *keyOrder = @[
         kErrorDetailActionNameKey, kErrorDetailElementMatcherKey, kErrorDetailRecoverySuggestionKey
@@ -688,12 +688,10 @@
     NSInteger errorCode = [errorDescriptions[kErrorCodeKey] integerValue];
     if (([errorDomain isEqualToString:kGREYInteractionErrorDomain]) &&
         (errorCode == kGREYInteractionTimeoutErrorCode)) {
-      errorDetails[kErrorDetailAssertCriteriaKey] = assertion.name;
-      errorDetails[kErrorDetailRecoverySuggestionKey] = @"Increase timeout for matching element";
+      errorDetails[kErrorDetailRecoverySuggestionKey] = @"Increase timeout for matching element.";
       errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
       NSArray *keyOrder = @[
-        kErrorDetailAssertCriteriaKey, kErrorDetailElementMatcherKey,
-        kErrorDetailRecoverySuggestionKey
+        kErrorDetailElementMatcherKey, kErrorDetailRecoverySuggestionKey
       ];
 
       NSString *reasonDetail = [GREYObjectFormatter formatDictionary:errorDetails
@@ -707,10 +705,8 @@
       [assertionError setErrorInfo:errorDetails];
     } else if (([errorDomain isEqualToString:kGREYUIThreadExecutorErrorDomain]) &&
                (errorCode == kGREYUIThreadExecutorTimeoutErrorCode)) {
-      errorDetails[kErrorDetailAssertCriteriaKey] = assertion.name;
       errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
-
-      NSArray *keyOrder = @[ kErrorDetailAssertCriteriaKey, kErrorDetailElementMatcherKey ];
+      NSArray *keyOrder = @[ kErrorDetailElementMatcherKey ];
       NSString *reasonDetail = [GREYObjectFormatter formatDictionary:errorDetails
                                                               indent:kGREYObjectFormatIndent
                                                            hideEmpty:YES

--- a/AppFramework/Core/GREYElementInteraction.m
+++ b/AppFramework/Core/GREYElementInteraction.m
@@ -688,10 +688,12 @@
     NSInteger errorCode = [errorDescriptions[kErrorCodeKey] integerValue];
     if (([errorDomain isEqualToString:kGREYInteractionErrorDomain]) &&
         (errorCode == kGREYInteractionTimeoutErrorCode)) {
+      errorDetails[kErrorDetailAssertCriteriaKey] = assertion.name;
       errorDetails[kErrorDetailRecoverySuggestionKey] = @"Increase timeout for matching element.";
       errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
       NSArray *keyOrder = @[
-        kErrorDetailElementMatcherKey, kErrorDetailRecoverySuggestionKey
+        kErrorDetailAssertCriteriaKey, kErrorDetailElementMatcherKey,
+        kErrorDetailRecoverySuggestionKey
       ];
 
       NSString *reasonDetail = [GREYObjectFormatter formatDictionary:errorDetails
@@ -705,8 +707,10 @@
       [assertionError setErrorInfo:errorDetails];
     } else if (([errorDomain isEqualToString:kGREYUIThreadExecutorErrorDomain]) &&
                (errorCode == kGREYUIThreadExecutorTimeoutErrorCode)) {
+      errorDetails[kErrorDetailAssertCriteriaKey] = assertion.name;
       errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
-      NSArray *keyOrder = @[ kErrorDetailElementMatcherKey ];
+
+      NSArray *keyOrder = @[ kErrorDetailAssertCriteriaKey, kErrorDetailElementMatcherKey ];
       NSString *reasonDetail = [GREYObjectFormatter formatDictionary:errorDetails
                                                               indent:kGREYObjectFormatIndent
                                                            hideEmpty:YES

--- a/CommonLib/Error/GREYErrorFormatter.m
+++ b/CommonLib/Error/GREYErrorFormatter.m
@@ -55,11 +55,13 @@ static NSString *const kHierarchyHeaderKey                       = @"UI Hierarch
 
 BOOL GREYShouldUseErrorFormatterForError(GREYError *error) {
   return [error.domain isEqualToString:kGREYInteractionErrorDomain] &&
-          error.code == kGREYInteractionElementNotFoundErrorCode;
+          (error.code == kGREYInteractionElementNotFoundErrorCode ||
+           error.code == kGREYInteractionTimeoutErrorCode);
 }
 
 BOOL GREYShouldUseErrorFormatterForExceptionReason(NSString *reason) {
-  return [reason containsString:@"the desired element was not found"];
+  return [reason containsString:@"the desired element was not found"] ||
+         [reason containsString:@"timed out"];
 }
 
 #pragma mark - Static Functions

--- a/CommonLib/Error/GREYErrorFormatter.m
+++ b/CommonLib/Error/GREYErrorFormatter.m
@@ -56,8 +56,8 @@ static NSString *const kErrorPrefix = @"EarlGrey Encountered an Error:";
 
 BOOL GREYShouldUseErrorFormatterForError(GREYError *error) {
   return [error.domain isEqualToString:kGREYInteractionErrorDomain] &&
-          (error.code == kGREYInteractionElementNotFoundErrorCode ||
-           error.code == kGREYInteractionTimeoutErrorCode);
+         (error.code == kGREYInteractionElementNotFoundErrorCode ||
+          error.code == kGREYInteractionTimeoutErrorCode);
 }
 
 BOOL GREYShouldUseErrorFormatterForDetails(NSString *failureHandlerDetails) {

--- a/Tests/Functional/Sources/FailureFormattingTest.m
+++ b/Tests/Functional/Sources/FailureFormattingTest.m
@@ -174,6 +174,9 @@
                               @"interactable Point:{nan, nan} && sufficientlyVisible(Expected: "
                               @"0.750000, Actual: 0.000000))\n"
                               @"\n"
+                              @"Assertion Criteria: assertWithMatcher:sufficientlyVisible(E"
+                              @"xpected: 0.750000, Actual: 0.000000)\n"
+                              @"\n"
                               @"UI Hierarchy";
   XCTAssertTrue([_handler.details containsString:expectedDetails]);
 }

--- a/Tests/Functional/Sources/FailureFormattingTest.m
+++ b/Tests/Functional/Sources/FailureFormattingTest.m
@@ -60,7 +60,7 @@
 - (void)setUp {
   [super setUp];
   _handler = [[FailureFormatTestingFailureHandler alloc] init];
-//  [NSThread mainThread].threadDictionary[GREYFailureHandlerKey] = _handler;
+  [NSThread mainThread].threadDictionary[GREYFailureHandlerKey] = _handler;
 }
 
 /// Tests the Element Not Found formatting for kGREYInteractionElementNotFoundErrorCode
@@ -163,12 +163,10 @@
       onElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
       assertWithMatcher:grey_sufficientlyVisible()
                   error:nil];
-  NSString *expectedDetails = @"Search action failed: Interaction cannot continue because the "
-                              @"desired element was not found.\n"
+  NSString *expectedDetails = @"Interaction timed out after 1 seconds while searching "
+                              @"for element.\n"
                               @"\n"
-                              @"Check if the element exists in the UI hierarchy printed below. If "
-                              @"it exists, adjust the matcher so that it accurately matches "
-                              @"the element.\n"
+                              @"Increase timeout for matching element.\n"
                               @"\n"
                               @"Element Matcher:\n"
                               @"(((respondsToSelector(isAccessibilityElement) && "
@@ -176,11 +174,7 @@
                               @"interactable Point:{nan, nan} && sufficientlyVisible(Expected: "
                               @"0.750000, Actual: 0.000000))\n"
                               @"\n"
-                              @"Assertion Criteria: assertWithMatcher:sufficientlyVisible(Expe"
-                              @"cted: 0.750000, Actual: 0.000000)\n"
-                              @"\n"
-                              @"Search API Info\n"
-                              @"Search Action: ";
+                              @"UI Hierarchy";
   XCTAssertTrue([_handler.details containsString:expectedDetails]);
 }
 

--- a/Tests/Functional/Sources/FailureFormattingTest.m
+++ b/Tests/Functional/Sources/FailureFormattingTest.m
@@ -60,7 +60,7 @@
 - (void)setUp {
   [super setUp];
   _handler = [[FailureFormatTestingFailureHandler alloc] init];
-  [NSThread mainThread].threadDictionary[GREYFailureHandlerKey] = _handler;
+//  [NSThread mainThread].threadDictionary[GREYFailureHandlerKey] = _handler;
 }
 
 /// Tests the Element Not Found formatting for kGREYInteractionElementNotFoundErrorCode
@@ -149,6 +149,38 @@
                               @"accessibilityID('TestWKWebView'))\n"
                               @"\n"
                               @"Action Name: Execute JavaScript";
+  XCTAssertTrue([_handler.details containsString:expectedDetails]);
+}
+
+- (void)testTimeoutErrorDescription {
+  [self openTestViewNamed:@"Scroll Views"];
+  id<GREYMatcher> matcher = grey_allOf(grey_accessibilityLabel(@"Label 2"), grey_interactable(),
+                                       grey_sufficientlyVisible(), nil);
+  [[GREYConfiguration sharedConfiguration] setValue:@(1)
+                                       forConfigKey:kGREYConfigKeyInteractionTimeoutDuration];
+  [[[EarlGrey selectElementWithMatcher:matcher]
+         usingSearchAction:grey_scrollInDirection(kGREYDirectionDown, 50)
+      onElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
+      assertWithMatcher:grey_sufficientlyVisible()
+                  error:nil];
+  NSString *expectedDetails = @"Search action failed: Interaction cannot continue because the "
+                              @"desired element was not found.\n"
+                              @"\n"
+                              @"Check if the element exists in the UI hierarchy printed below. If "
+                              @"it exists, adjust the matcher so that it accurately matches "
+                              @"the element.\n"
+                              @"\n"
+                              @"Element Matcher:\n"
+                              @"(((respondsToSelector(isAccessibilityElement) && "
+                              @"isAccessibilityElement) && accessibilityLabel('Label 2')) && "
+                              @"interactable Point:{nan, nan} && sufficientlyVisible(Expected: "
+                              @"0.750000, Actual: 0.000000))\n"
+                              @"\n"
+                              @"Assertion Criteria: assertWithMatcher:sufficientlyVisible(Expe"
+                              @"cted: 0.750000, Actual: 0.000000)\n"
+                              @"\n"
+                              @"Search API Info\n"
+                              @"Search Action: ";
   XCTAssertTrue([_handler.details containsString:expectedDetails]);
 }
 


### PR DESCRIPTION
This change tracks the formatting of kGREYInteractionTimeoutErrorCode

Consider this code, which results in an interaction timeout failure:
```
  [self openTestViewNamed:@"Scroll Views"];
  id<GREYMatcher> matcher = grey_allOf(grey_accessibilityLabel(@"Label 2"), grey_interactable(), grey_sufficientlyVisible(), nil);
  [[GREYConfiguration sharedConfiguration] setValue:@(1) forConfigKey:kGREYConfigKeyInteractionTimeoutDuration];
  [[[EarlGrey selectElementWithMatcher:matcher] usingSearchAction:grey_scrollInDirection(kGREYDirectionDown, 50) onElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")] assertWithMatcher:grey_sufficientlyVisible() error:nil];
```

Avg Execution Time, before:  5.4s
Avg Execution Time, after: 5.3 s

Console Output, before:
```
Exception Name: com.google.earlgrey.ElementInteractionErrorDomain
Exception Reason: Interaction timed out after 1 seconds while searching for element.
Exception Details: Matching element timed out.
Exception with Assertion: {
  "Assertion Criteria" : "assertWithMatcher:sufficientlyVisible(Expected: 0.750000, Actual: 0.000000)",
  "Element Matcher" : "(((respondsToSelector(isAccessibilityElement) && isAccessibilityElement) && accessibilityLabel('Label 2')) && interactable Point:{nan, nan} && sufficientlyVisible(Expected: 0.750000, Actual: 0.000000))",
  "Recovery Suggestion" : "Increase timeout for matching element"
}

Screenshots: ...

UI Hierarchy: ...

Stack Trace: ...
```

Console Output, after:
```
EarlGrey Encountered an Error:

Interaction timed out after 1 seconds while searching for element.

Increase timeout for matching element.

Element Matcher:
(((respondsToSelector(isAccessibilityElement) && isAccessibilityElement) && accessibilityLabel('Label 2')) && interactable Point:{nan, nan} && sufficientlyVisible(Expected: 0.750000, Actual: 0.000000))

Assertion Criteria: assertWithMatcher:sufficientlyVisible(Expected: 0.750000, Actual: 0.000000)

Screenshots: ...

UI Hierarchy: ...

Stack Trace: ...
```

Note that "EarlGrey Encountered an Error:" is temporary, until all error codes are using GREYErrorFormatter.