### PR TITLE
action interaction errors

### DIFF
--- a/CommonLib/Error/GREYErrorFormatter.m
+++ b/CommonLib/Error/GREYErrorFormatter.m
@@ -55,11 +55,28 @@ static NSString *const kHierarchyHeaderKey                       = @"UI Hierarch
 
 BOOL GREYShouldUseErrorFormatterForError(GREYError *error) {
   return [error.domain isEqualToString:kGREYInteractionErrorDomain] &&
-          error.code == kGREYInteractionElementNotFoundErrorCode;
+         (error.code == kGREYInteractionElementNotFoundErrorCode ||
+          error.code == kGREYInteractionActionFailedErrorCode);
 }
 
 BOOL GREYShouldUseErrorFormatterForExceptionReason(NSString *reason) {
-  return [reason containsString:@"the desired element was not found"];
+  return [reason containsString:@"the desired element was not found"] ||
+         [reason containsString:@"Failed to type"] ||
+         [reason containsString:@"GREYKeyboard: No known SHIFT key"] ||
+         [reason containsString:@"Reason for action failure was not provided."] ||
+         [reason containsString:@"Failed to take snapshot."] ||
+         [reason containsString:@"Keyboard did not appear after tapping on an element"] ||
+         [reason containsString:@"First Responder of Element does not conform to UITextInput"] ||
+         [reason containsString:@"Failed to find stepper buttons"] ||
+         [reason containsString:@"Cannot set stepper value due to"] ||
+         [reason containsString:@"Failed to exactly step to"] ||
+         [reason containsString:@"Failed to find Picker Column."] ||
+         [reason containsString:@"UIPickerView does not contain"] ||
+         [reason containsString:@"Slider's Minimum is"] ||
+         [reason containsString:@"Element is not attached to a window"] ||
+         [reason containsString:@"Unknown tap type"] ||
+         [reason containsString:@"it is outside window's bounds"] ||
+         [reason containsString:@"Deeplink open action failed"];
 }
 
 #pragma mark - Static Functions

--- a/Tests/Functional/Sources/FailureFormattingTest.m
+++ b/Tests/Functional/Sources/FailureFormattingTest.m
@@ -152,4 +152,19 @@
   XCTAssertTrue([_handler.details containsString:expectedDetails]);
 }
 
+- (void)testActionInteractionErrorDescription {
+  [[EarlGrey selectElementWithMatcher:grey_text(@"Basic Views")] performAction:grey_tap()];
+  [[EarlGrey selectElementWithMatcher:grey_text(@"Tab 2")] performAction:grey_tap()];
+  [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"foo")]
+      performAction:grey_typeText(@"")];
+  
+  NSString *expectedDetails = @"Failed to type because the provided string was empty.\n"
+                              @"\n"
+                              @"Element Matcher:\n"
+                              @"(respondsToSelector(accessibilityIdentifier) && accessibilityID('foo'))\n"
+                              @"\n"
+                              @"UI Hierarchy";
+  XCTAssertTrue([_handler.details containsString:expectedDetails]);
+}
+
 @end


### PR DESCRIPTION
This change tracks the adoption of GREYErrorFormatter for kGREYInteractionActionFailedErrorCode

Console Output, Before:
```
Exception: com.google.earlgrey.ElementInteractionErrorDomain

Exception Name: com.google.earlgrey.ElementInteractionErrorDomain
Exception Reason: Failed to type because the provided string was empty.
Exception Details: 
Failed to type because the provided string was empty.

Element Matcher:
(respondsToSelector(accessibilityIdentifier) && accessibilityID('foo'))

UI Hierarchy: ...

Screenshots: ...

Stack Trace: ...
```

Console Output, After:
```
EarlGrey Encountered an Error:

Failed to type because the provided string was empty.

Element Matcher:
(respondsToSelector(accessibilityIdentifier) && accessibilityID('foo'))

UI Hierarchy: ...

Screenshots: ...

Stack Trace: ...
```

Note that "EarlGrey Encountered an Error:" is temporary, until all error codes are using GREYErrorFormatter.