### PR TITLE
failed-criteria

### DIFF
--- a/CommonLib/Error/GREYError.m
+++ b/CommonLib/Error/GREYError.m
@@ -23,9 +23,9 @@
 NSString *const kGREYGenericErrorDomain = @"com.google.earlgrey.GenericErrorDomain";
 NSInteger const kGREYGenericErrorCode = 0;
 NSString *const kErrorDetailFailureNameKey = @"Failure Name";
-NSString *const kErrorDetailActionNameKey = @"Action Name";
+NSString *const kErrorDetailActionNameKey = @"Failing Action";
 NSString *const kErrorDetailSearchActionInfoKey = @"Search API Info";
-NSString *const kErrorDetailAssertCriteriaKey = @"Assertion Criteria";
+NSString *const kErrorDetailAssertCriteriaKey = @"Failing Assertion";
 NSString *const kErrorDetailRecoverySuggestionKey = @"Recovery Suggestion";
 
 NSString *const kErrorDomainKey = @"Error Domain";

--- a/CommonLib/Error/GREYErrorFormatter.m
+++ b/CommonLib/Error/GREYErrorFormatter.m
@@ -110,13 +110,11 @@ static NSString *LoggerDescription(GREYError *error) {
   
   NSString *assertionCriteria = error.userInfo[kErrorDetailAssertCriteriaKey];
   if (assertionCriteria) {
-    [logger addObject:[NSString stringWithFormat:@"%@: %@", kErrorDetailAssertCriteriaKey,
-                       assertionCriteria]];
+    [logger addObject:[NSString stringWithFormat:@"Failed Assertion: %@", assertionCriteria]];
   }
   NSString *actionCriteria = error.userInfo[kErrorDetailActionNameKey];
   if (actionCriteria) {
-    [logger addObject:[NSString stringWithFormat:@"%@: %@", kErrorDetailActionNameKey,
-                       actionCriteria]];
+    [logger addObject:[NSString stringWithFormat:@"Failed Action: %@", actionCriteria]];
   }
   
   NSString *searchActionInfo = error.userInfo[kErrorDetailSearchActionInfoKey];

--- a/CommonLib/Error/GREYErrorFormatter.m
+++ b/CommonLib/Error/GREYErrorFormatter.m
@@ -110,11 +110,13 @@ static NSString *LoggerDescription(GREYError *error) {
   
   NSString *assertionCriteria = error.userInfo[kErrorDetailAssertCriteriaKey];
   if (assertionCriteria) {
-    [logger addObject:[NSString stringWithFormat:@"Failed Assertion: %@", assertionCriteria]];
+    [logger addObject:[NSString stringWithFormat:@"%@: %@", kErrorDetailAssertCriteriaKey,
+                       assertionCriteria]];
   }
   NSString *actionCriteria = error.userInfo[kErrorDetailActionNameKey];
   if (actionCriteria) {
-    [logger addObject:[NSString stringWithFormat:@"Failed Action: %@", actionCriteria]];
+    [logger addObject:[NSString stringWithFormat:@"%@: %@", kErrorDetailActionNameKey,
+                       actionCriteria]];
   }
   
   NSString *searchActionInfo = error.userInfo[kErrorDetailSearchActionInfoKey];

--- a/Tests/Functional/Sources/FailureFormattingTest.m
+++ b/Tests/Functional/Sources/FailureFormattingTest.m
@@ -86,7 +86,7 @@
                               @"((kindOfClass('UILabel') || kindOfClass('UITextField') || "
                               @"kindOfClass('UITextView')) && hasText('Basic Views'))\n"
                               @"\n"
-                              @"Assertion Criteria: assertWithMatcher:isNotNil";
+                              @"Failing Assertion: assertWithMatcher:isNotNil";
   XCTAssertTrue([_handler.details containsString:expectedDetails]);
 }
 
@@ -115,7 +115,7 @@
                               @"interactable Point:{nan, nan} && sufficientlyVisible(Expected: "
                               @"0.750000, Actual: 0.000000))\n"
                               @"\n"
-                              @"Assertion Criteria: assertWithMatcher:sufficientlyVisible(Expe"
+                              @"Failing Assertion: assertWithMatcher:sufficientlyVisible(Expe"
                               @"cted: 0.750000, Actual: 0.000000)\n"
                               @"\n"
                               @"Search API Info\n"
@@ -148,7 +148,7 @@
                               @"(respondsToSelector(accessibilityIdentifier) && "
                               @"accessibilityID('TestWKWebView'))\n"
                               @"\n"
-                              @"Action Name: Execute JavaScript";
+                              @"Failing Action: Execute JavaScript";
   XCTAssertTrue([_handler.details containsString:expectedDetails]);
 }
 


### PR DESCRIPTION
In the GREYErrorFormatter, this changes the output key for failed criteria from "Assertion Criteria" or "Action Name" to "Failing Assertion" or "Failing Action", depending on whether an assertion or action failed.